### PR TITLE
Use a dedicated ActiveSupport::Deprecate instance

### DIFF
--- a/lib/administrate.rb
+++ b/lib/administrate.rb
@@ -2,7 +2,7 @@ require "administrate/engine"
 
 module Administrate
   def self.warn_of_missing_resource_class
-    ActiveSupport::Deprecation.warn(
+    deprecator.warn(
       "Calling Field::Base.permitted_attribute without the option " +
       ":resource_class is deprecated. If you are seeing this " +
       "message, you are probably using a custom field type that" +
@@ -12,7 +12,7 @@ module Administrate
   end
 
   def self.warn_of_deprecated_option(name)
-    ActiveSupport::Deprecation.warn(
+    deprecator.warn(
       "The option :#{name} is deprecated. " +
       "Administrate should detect it automatically. " +
       "Please file an issue at " +
@@ -22,7 +22,7 @@ module Administrate
   end
 
   def self.warn_of_deprecated_method(klass, method)
-    ActiveSupport::Deprecation.warn(
+    deprecator.warn(
       "The method #{klass}##{method} is deprecated. " +
       "If you are seeing this message you are probably " +
       "using a dashboard that depends explicitly on it. " +
@@ -32,10 +32,14 @@ module Administrate
   end
 
   def self.warn_of_deprecated_authorization_method(method)
-    ActiveSupport::Deprecation.warn(
+    deprecator.warn(
       "The method `#{method}` is deprecated. " +
       "Please use `accessible_action?` instead, " +
       "or see the documentation for other options.",
     )
+  end
+
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new(VERSION, "Administrate")
   end
 end

--- a/spec/controllers/admin/application_controller_spec.rb
+++ b/spec/controllers/admin/application_controller_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe Admin::ApplicationController, type: :controller do
     end
 
     it "triggers a deprecation warning" do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
       get :index
-      expect(ActiveSupport::Deprecation).to(
+      expect(Administrate.deprecator).to(
         have_received(:warn).
           with(/`show_action\?` is deprecated/),
       )
@@ -99,9 +99,9 @@ RSpec.describe Admin::ApplicationController, type: :controller do
     end
 
     it "triggers a deprecation warning" do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
       get :index
-      expect(ActiveSupport::Deprecation).to(
+      expect(Administrate.deprecator).to(
         have_received(:warn).
           with(/`valid_action\?` is deprecated/),
       )

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -73,8 +73,8 @@ describe Administrate::Search do
     Administrate.send(:remove_const, :SearchSpecMocks)
   end
 
-  before { ActiveSupport::Deprecation.silenced = true }
-  after { ActiveSupport::Deprecation.silenced = false }
+  before { Administrate.deprecator.silenced = true }
+  after { Administrate.deprecator.silenced = false }
 
   describe "#run" do
     it "returns all records when no search term" do
@@ -159,7 +159,7 @@ describe Administrate::Search do
 
     context "when searching through associations" do
       before do
-        allow(ActiveSupport::Deprecation).to receive(:warn)
+        allow(Administrate.deprecator).to receive(:warn)
       end
 
       let(:scoped_object) { Administrate::SearchSpecMocks::Foo }
@@ -217,7 +217,7 @@ describe Administrate::Search do
 
         search.run
 
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
+        expect(Administrate.deprecator).to have_received(:warn).
           with(/:class_name is deprecated/)
       end
     end

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -88,7 +88,7 @@ describe Administrate::Field::BelongsTo do
 
   describe "class_name option" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
     end
 
     it "determines the associated_class" do
@@ -134,7 +134,7 @@ describe Administrate::Field::BelongsTo do
         resource: line_item,
       )
       field.associated_class
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
+      expect(Administrate.deprecator).to have_received(:warn).
         with(/:class_name is deprecated/)
     end
   end
@@ -179,7 +179,7 @@ describe Administrate::Field::BelongsTo do
 
   describe "primary_key option" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
 
       Foo = Class.new
       FooDashboard = Class.new
@@ -217,14 +217,14 @@ describe Administrate::Field::BelongsTo do
       field = association.new(:foo, double(uuid: nil), :baz)
       field.selected_option
 
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
+      expect(Administrate.deprecator).to have_received(:warn).
         with(/:primary_key is deprecated/)
     end
   end
 
   describe "foreign_key option" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
     end
 
     it "determines what foreign key is used on the relationship for the form" do
@@ -244,7 +244,7 @@ describe Administrate::Field::BelongsTo do
 
       field.permitted_attribute
 
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
+      expect(Administrate.deprecator).to have_received(:warn).
         with(/:foreign_key is deprecated/)
     end
   end

--- a/spec/lib/fields/deferred_spec.rb
+++ b/spec/lib/fields/deferred_spec.rb
@@ -8,7 +8,7 @@ describe Administrate::Field::Deferred do
   describe "#permitted_attribute" do
     context "when given a `foreign_key` option" do
       before do
-        allow(ActiveSupport::Deprecation).to receive(:warn)
+        allow(Administrate.deprecator).to receive(:warn)
       end
 
       it "returns the value given" do
@@ -26,7 +26,7 @@ describe Administrate::Field::Deferred do
           foreign_key: :bar,
         )
         deferred.permitted_attribute(:foo, resource_class: LineItem)
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
+        expect(Administrate.deprecator).to have_received(:warn).
           with(/:foreign_key is deprecated/)
       end
     end

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -36,7 +36,7 @@ describe Administrate::Field::HasMany do
     let(:dashboard_double) { double(collection_attributes: []) }
 
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
 
       FooDashboard = Class.new
       allow(FooDashboard).to receive(:new).and_return(dashboard_double)
@@ -63,14 +63,14 @@ describe Administrate::Field::HasMany do
       field = association.new(:customers, [], :show)
       field.associated_collection
 
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
+      expect(Administrate.deprecator).to have_received(:warn).
         with(/:class_name is deprecated/)
     end
   end
 
   describe "primary_key option" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
 
       Foo = Class.new
       FooDashboard = Class.new
@@ -108,7 +108,7 @@ describe Administrate::Field::HasMany do
       field = association.new(:customers, [], :show)
       field.associated_resource_options
 
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
+      expect(Administrate.deprecator).to have_received(:warn).
         with(/:primary_key is deprecated/)
     end
   end

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -43,7 +43,7 @@ describe Administrate::Field::HasOne do
   describe ".permitted_attribute" do
     context "with custom class_name" do
       before do
-        allow(ActiveSupport::Deprecation).to receive(:warn)
+        allow(Administrate.deprecator).to receive(:warn)
       end
 
       it "returns attributes from correct dashboard" do
@@ -71,7 +71,7 @@ describe Administrate::Field::HasOne do
           field_name,
           resource_class: Product,
         )
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
+        expect(Administrate.deprecator).to have_received(:warn).
           with(/:class_name is deprecated/)
       end
     end


### PR DESCRIPTION
Rails 7.1 started deprecating the direct usage of ActiveSupport::Deprecate methods. Instead, the preferred way is to instantiate the class and use the custom instance.

Compatible with Rails 4.0+